### PR TITLE
Tidy up benchmarking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Editor backup files
+*~

--- a/benchmark-beebs.py
+++ b/benchmark-beebs.py
@@ -31,25 +31,30 @@ class RunCommandError(RuntimeError):
     '''Exception raised when something went wrong with execution of command.'''
     pass
 
+
+# This version comment out capture_output arg to subprocess.run (not supported
+# in older releases of Python) and associated calls to decode().
+
 def run_command(args, *, timeout, work_dir, toolchain_dir):
     log.debug('Running %s' % " ".join(args))
     path = toolchain_dir + os.pathsep + os.environ['PATH']
     env = { 'PATH': path }
     try:
-        cp = subprocess.run(args, capture_output=True, check=True, timeout=timeout, cwd=work_dir, env=env)
+        cp = subprocess.run(args, check=True, timeout=timeout, cwd=work_dir, env=env)
+#        cp = subprocess.run(args, capture_output=True, check=True, timeout=timeout, cwd=work_dir, env=env)
         log.info('Process exited normally')
-        log.debug('Stdout:\n\n%s\n\n' % cp.stdout.decode())
-        log.debug('Stderr:\n\n%s\n\n' % cp.stderr.decode())
+#        log.debug('Stdout:\n\n%s\n\n' % cp.stdout.decode())
+#        log.debug('Stderr:\n\n%s\n\n' % cp.stderr.decode())
         return
     except subprocess.TimeoutExpired as e:
         log.info('Execution timeout (%ss) expired') % timeout
-        log.info('Stdout:\n\n%s\n\n' % e.stdout.decode())
-        log.info('Stderr:\n\n%s\n\n' % e.stderr.decode())
+#        log.info('Stdout:\n\n%s\n\n' % e.stdout.decode())
+#        log.info('Stderr:\n\n%s\n\n' % e.stderr.decode())
         raise RunCommandError
     except subprocess.CalledProcessError as e:
         log.info('Process exited abnormally with code %s' % e.returncode)
-        log.info('Stdout:\n\n%s\n\n' % e.stdout.decode())
-        log.info('Stderr:\n\n%s\n\n' % e.stderr.decode())
+#        log.info('Stdout:\n\n%s\n\n' % e.stdout.decode())
+#        log.info('Stderr:\n\n%s\n\n' % e.stderr.decode())
         raise RunCommandError
 
 def build(host, config):

--- a/grab-results.sh
+++ b/grab-results.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+# Copyright (C) 2019 Embecosm Limited
+
+# Contributor Jeremy Bennett <jeremy.bennett@embecosm.com>
+
+# This file is part of the build system for RISC-V
+
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation; either version 3 of the License, or (at your option)
+# any later version.
+
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Break out the results from BEEBS runs
+
+if [ $# -ne 1 ]
+then
+    echo "Usage: grab-results.sh <rootdir>"
+    exit 1
+fi
+
+rootdir=$(cd $1; pwd)
+
+tests="baseline nocrt nolibc nolibc-nolibgcc nolibc-nolibgcc-nolibm"
+archs="riscv arm arc"
+
+for a in ${archs}
+do
+    for t in ${tests}
+    do
+	sed < ${rootdir}/build-${a}/beebs-${t}/testsuite/beebs.log \
+	    -n -e '/Benchmark               Text/,/Total              /p' |
+	    sed -n -e '/^[a-z]/p' |
+	    sed -e 's/^\([^ ]\+\)[^0-9]\+\([0-9]\+\)[^0-9]\+\([0-9]\+\)[^0-9]\+\([0-9]\+\)/"\1","\2","\3","\4"/' > ${a}-${t}.csv
+    done
+done


### PR DESCRIPTION
	This comments out some functionality in benchmark-beebs.py which is not
	supported in older versions of Python.  It also adds a script to grab
	the results data for a set of BEEBS size runs.  Finally .gitignore is
	used to ignore editor backups.

Files changed:

	* .gitignore: Created.
	* benchmark-beebs.py: Use older version of subprocess.run in
	run_command and comment out associated calls to the decode()
	procedure.
	* grab-results.sh: Created.