### PR TITLE
Fix setting of GCC_BUILD_DIR in run-tests.sh

### DIFF
--- a/build-riscv.sh
+++ b/build-riscv.sh
@@ -9,6 +9,7 @@ CLEAN_BUILD=no
 DEBUG_BUILD=no
 BUILD_DIR=${TOP}/build-riscv
 INSTALL_DIR=${TOP}/install-riscv
+MULTILIB_BUILD='--disable-multilib'
 
 # ====================================================================
 
@@ -105,6 +106,10 @@ case ${opt} in
 
     --debug)
 	DEBUG_BUILD=yes
+	;;
+
+    --multilib)
+	MULTILIB_BUILD='--enable-multilib'
 	;;
 
     --with-xlen)

--- a/common.sh
+++ b/common.sh
@@ -199,8 +199,7 @@ function build_binutils_gdb ()
              --target=${TARGET_TRIPLET} \
              --with-sysroot=${SYSROOT_DIR} \
              --enable-poison-system-directories \
-             --disable-tls \
-             --disable-sim
+             --disable-tls
     then
         error "Failed to configure binutils and GDB"
     fi

--- a/common.sh
+++ b/common.sh
@@ -195,7 +195,7 @@ function build_binutils_gdb ()
              --disable-documentation \
              --with-xmlto=no \
              --with-fop=no \
-             --disable-multilib \
+             ${MULTILIB_BUILD} \
              --target=${TARGET_TRIPLET} \
              --with-sysroot=${SYSROOT_DIR} \
              --enable-poison-system-directories \
@@ -246,7 +246,7 @@ function build_gcc_stage_1 ()
                --disable-__cxa_atexit \
                --with-gnu-ld \
                --disable-libssp \
-               --disable-multilib \
+               ${MULTILIB_BUILD} \
                --enable-target-optspace \
                --disable-libsanitizer \
                --disable-tls \
@@ -355,7 +355,7 @@ function build_gcc_stage_2 ()
                --disable-__cxa_atexit \
                --with-gnu-ld \
                --disable-libssp \
-               --disable-multilib \
+               ${MULTILIB_BUILD} \
                --enable-target-optspace \
                --disable-libsanitizer \
                --disable-tls \

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -21,8 +21,6 @@ TARGET_SUBSET=
 TOOL=gcc
 COMMENT="none"
 
-GCC_BUILD_DIR=${BUILD_DIR}/gcc-stage-2
-
 # Default parallellism
 processor_count="`(echo processor; cat /proc/cpuinfo 2>/dev/null echo processor) \
            | grep -c processor`"
@@ -126,6 +124,7 @@ rm -f ${RESULTS_DIR}/*
 # ====================================================================
 
 GDB_BUILD_DIR=${BUILD_DIR}/gdb
+GCC_BUILD_DIR=${BUILD_DIR}/gcc-stage-2
 
 # ====================================================================
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -123,7 +123,7 @@ rm -f ${RESULTS_DIR}/*
 
 # ====================================================================
 
-GDB_BUILD_DIR=${BUILD_DIR}/gdb
+GDB_BUILD_DIR=${BUILD_DIR}/binutils-gdb
 GCC_BUILD_DIR=${BUILD_DIR}/gcc-stage-2
 
 # ====================================================================

--- a/scripts/riscv32-unknown-elf-run
+++ b/scripts/riscv32-unknown-elf-run
@@ -1,3 +1,1 @@
-#!/bin/bash
-
-qemu-riscv32 "$@"
+riscv64-unknown-elf-run

--- a/scripts/riscv64-unknown-elf-run
+++ b/scripts/riscv64-unknown-elf-run
@@ -1,3 +1,9 @@
 #!/bin/bash
 
-qemu-riscv64 "$@"
+if readelf -h $1 | grep 'Class:\s*ELF32$'
+then
+  qemu-riscv32 "$@"
+else
+  qemu-riscv64 "$@"
+fi
+


### PR DESCRIPTION
GCC_BUILD_DIR was always being set based on the default BUILD_DIR.
This fix sets GCC_BUILD_DIR after the command line arguments have
been parsed.

ChangeLog:

	* run-tests.sh: Set GCC_BUILD_DIR after command line
	arguments are parsed.